### PR TITLE
Parameterize test_driver.py with PARSER_CMD

### DIFF
--- a/c/test_driver.py
+++ b/c/test_driver.py
@@ -87,7 +87,7 @@ def runtest(testname, flag=None):
     else:
         args = []
 
-    args.append('./sqli')
+    args.append(os.getenv('PARSER_CMD', './sqli'))
 
     if flag:
         args.append(flag)


### PR DESCRIPTION
I use this to run the test suite with the C# and Java implementations.

Feel free to rename `PARSER_CMD` to something better.
