### PR TITLE
updating the example to inlcude the correct number of appropriate parameters

### DIFF
--- a/php/example.php
+++ b/php/example.php
@@ -11,8 +11,10 @@ $x = new_libinjection_sqli_state();
 // pass it in to init
 // arg 1 -- state objection above
 // arg 2 -- php string of input -- MUST BE URL-DECODED
-// arg 3 -- flags -- just pass in '0' for now
-libinjection_sqli_init($x, "1 union select 1,2,3,4--", 0);
+// arg 3 -- the length of the string of input
+// arg 4 -- flags -- just pass in '0' for now
+$input = "1 union select 1,2,3,4--";
+libinjection_sqli_init($x, $input, strlen($input), 0);
 
 // do a test
 $sqli = libinjection_is_sqli($x);


### PR DESCRIPTION
The php example only has 3 params and returns an error like this:

```
[marpaia@marpaia] php (master):php example.php
Using libinjection 3.6.0pre1

Warning: Wrong parameter count for libinjection_sqli_init() in /home/marpaia/development/libinjection/php/example.php on line 15
```

Applying the submitted patch returns correct output:

```
[marpaia@marpaia] php (master):php example.php
Using libinjection 3.6.0pre1
sqli with fingerprint 1UE1c
```
