### PR TITLE
Adds stddef include to swig interface file

### DIFF
--- a/python/libinjection/libinjection.i
+++ b/python/libinjection/libinjection.i
@@ -3,6 +3,7 @@
 %{
 #include "libinjection.h"
 #include "libinjection_sqli.h"
+#include <stddef.h>
 
 /* This is the callback function that runs a python function
  *


### PR DESCRIPTION
On some newer OSes swig won't build because the interface file misses stddef.h.
This is similar to https://github.com/PixarAnimationStudios/OpenSubdiv/issues/264 issue.

This change solves the problem for me.
