### PR TITLE
Fix invocation of `ar` in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 
-AR=ar r
+AR=ar -r
 CC=cc
 LD=ld
 LDSHARED=ld -shared
@@ -63,7 +63,7 @@ ${SHAREDLIB}: ${OBJECTS}
 
 ${STATICLIB}: ${OBJECTS}
 	rm -f ${STATICLIB}
-	${AR} -o ${STATICLIB} ${OBJECTS}
+	${AR} ${STATICLIB} ${OBJECTS}
 
 check: ${TESTDRIVERS}
 	@./test-driver.sh test-unit.sh


### PR DESCRIPTION
Currently, libinjection.a is built by invoking `ar r -o libinjection.a <OBJS>`.
We noticed that in our build environment, which runs atop Ubuntu Lucid, our
version of ar seems to get confused with that invocation.

```
nathan@lucid $ ar --version
GNU ar (GNU Binutils for Ubuntu) 2.20.1-system.20100303
<snip>
nathan@lucid $ make
<snip>
ar r -o libinjection.a libinjection_sqli.o libinjection_html5.o libinjection_xss.o
ar: creating -o
ar: libinjection.a: No such file or directory
make: *** [libinjection.a] Error 1
```

This patch changes the arguments to `ar` slightly to succeed in both
environments by adding the optional hyphen.  (Also, it removes the
superfluous -o flag, which is only relevant for extracting archives,
not creation.)

Older host:
```
nathan@lucid $ ar --version
GNU ar (GNU Binutils for Ubuntu) 2.20.1-system.20100303
nathan@lucid $ make
<snip>
ar -r libinjection.a libinjection_sqli.o libinjection_html5.o libinjection_xss.o
ar: creating libinjection.a
```

Newer host:
```
nathan@ubuntu libinjection/src (dijkstracula/ar_invocation) » ar --version
GNU ar (GNU Binutils for Ubuntu) 2.24
<snip>
nathan@ubuntu libinjection/src (dijkstracula/ar_invocation) » make
<snip>
ar -r libinjection.a libinjection_sqli.o libinjection_html5.o libinjection_xss.o
ar: creating libinjection.a
nathan@ubuntu libinjection/src (dijkstracula/ar_invocation) » 
```