### PR TITLE
Fix for MySQL, MSSQL whitespace evasion

### DIFF
--- a/src/libinjection_sqli.c
+++ b/src/libinjection_sqli.c
@@ -177,7 +177,7 @@ strlencspn(const char *s, size_t len, const char *accept)
         /* likely we can do better by inlining this function
          * but this works for now
          */
-        if (strchr(accept, s[i]) != NULL) {
+        if (s[i]<32 || strchr(accept, s[i]) != NULL) {
             return i;
         }
     }


### PR DESCRIPTION
Quick fix for http://www.websec.ca/blog/view/Bypassing_WAFs_with_SQLMap#sthash.uNJMATB3.dpuf%27=
where it states: "MySQL allows characters 09, 0A-0D, A0 to be used as whitespaces while MSSQL allows a much wider range, from 01-1F.".