### PR TITLE
Optimize libinjection_sqli_token layout

### DIFF
--- a/src/libinjection_sqli.h
+++ b/src/libinjection_sqli.h
@@ -40,10 +40,6 @@ struct libinjection_sqli_token {
 #ifdef SWIG
 %immutable;
 #endif
-    char type;
-    char str_open;
-    char str_close;
-
     /*
      * position and length of token
      * in original string
@@ -57,6 +53,9 @@ struct libinjection_sqli_token {
      */
     int  count;
 
+    char type;
+    char str_open;
+    char str_close;
     char val[32];
 };
 


### PR DESCRIPTION
Save 8 bytes in each libinjection_sqli_token by adjusting the struct
layout. This results in each libinjection_sqli_token using 56 bytes
(previously using 64); additionally, each libinjection_sqli_state now
uses 544 bytes (previously 608).
