### PR TITLE
Fix buffer over-read in xss detection/h3_stat_tag_open

### DIFF
--- a/src/libinjection_html5.c
+++ b/src/libinjection_html5.c
@@ -180,6 +180,9 @@ static int h5_state_tag_open(h5_state_t* hs)
     char ch;
 
     TRACE();
+    if (hs->pos >= hs->len) {
+        return 0;
+    }
     ch = hs->s[hs->pos];
     if (ch == CHAR_BANG) {
         hs->pos += 1;


### PR DESCRIPTION
Originally reported by @jvoisin at #116