### PR TITLE
solves false positive for URLs such as "/on=x"

### DIFF
--- a/src/libinjection_xss.c
+++ b/src/libinjection_xss.c
@@ -340,14 +340,15 @@ static attribute_t is_black_attr(const char* s, size_t len)
         return TYPE_NONE;
     }
 
-    /* JavaScript on.* */
-    if ((s[0] == 'o' || s[0] == 'O') && (s[1] == 'n' || s[1] == 'N')) {
-        /* printf("Got JavaScript on- attribute name\n"); */
-        return TYPE_BLACK;
-    }
-
-
     if (len >= 5) {
+        /* JavaScript on.* */
+        if ((s[0] == 'o' || s[0] == 'O') && (s[1] == 'n' || s[1] == 'N')) {
+            /* printf("Got JavaScript on- attribute name\n"); */
+            return TYPE_BLACK;
+        }
+
+
+
         /* XMLNS can be used to create arbitrary tags */
         if (cstrcasecmp_with_null("XMLNS", s, 5) == 0 || cstrcasecmp_with_null("XLINK", s, 5) == 0) {
             /*      printf("Got XMLNS and XLINK tags\n"); */


### PR DESCRIPTION
Given "on" by itself is not an issue, rather onxxxx is, the len >=5 should be wrapping the "on" test as well
The code as is right now, causes false positive on legit URLs such as "/on=1"

/* JavaScript on.* 
onload,onmove,onclick,onabort,onerror,onkeyup,onfocus,onresize,
onselect,onsubmit,onunload,onchange,onmouseup,onkeydown,onkeypress,
onmouseout,ondragdrop,onmousedown,onmousemove,onmouseover
*/