### PR TITLE
Have `sqlparse_data.json` depend on `fingerprint.txt`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,7 +47,7 @@ fingerprints:
 	mv fingerprints2.txt fingerprints.txt
 .PHONY: fingerprints
 
-sqlparse_data.json: sqlparse_map.py fingerprints
+sqlparse_data.json: sqlparse_map.py fingerprints.txt
 	./sqlparse_map.py > sqlparse_data.json
 
 libinjection_sqli_data.h: sqlparse2c.py sqlparse_data.json


### PR DESCRIPTION
Depending on `fingerprints` makes `make` rebuild `fingerprints.txt`
everytime, which in turns rebuilds `sqlparse_data.json`, and
`libinjection_sqli_data.h`