### PR TITLE
Specify Python version explicitly in shebangs

### DIFF
--- a/src/fingerprints2sqli.py
+++ b/src/fingerprints2sqli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 Small script to convert fingerprints back to SQL or SQLi
 """

--- a/src/make_parens.py
+++ b/src/make_parens.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # pylint: disable=C0103,R0911,R0912,R0915
 # disable short-variable-names, too many branches, returns, statements
 """

--- a/src/sqlparse2c.py
+++ b/src/sqlparse2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #  Copyright 2012, 2013 Nick Galbreath
 #  nickg@client9.com

--- a/src/sqlparse_map.py
+++ b/src/sqlparse_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # pylint: disable=C0301,C0302
 # Turn off line-too-long, and too-many-lines warnings
 #


### PR DESCRIPTION
Fixes compilation failures in distributions that have 'python' refer to Python 3.

See issue #92.